### PR TITLE
set mode and action depending on tiko states

### DIFF
--- a/tiko/CHANGELOG.md
+++ b/tiko/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0
+
+- ⚠️ Breaking change! Previously, the heater `mode` would be `heat` when actually heating, and `off` when not, and the `action` would not be set.
+This new version implements the correct behavior: the `mode` is either `heat` when the heater is on (whether it's actually heating or not), or `off` if it's off. `action` is either `off` when the heater is off, `idle` when the heater is on but not actually heating, and `heating` when it's actually heating.
+
+  This should help with integrations like Versatile Thermostat. Thanks to @tduboys for reporting and fixing the bug!
+
 ## 1.4.7
 
 - Fix API inconsistency when fetching the sensors status

--- a/tiko/Dockerfile
+++ b/tiko/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/aarch64:15.0.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM} as base
 
-RUN apk add --no-cache nodejs=20.12.1-r0 tini=0.19.0-r2
+RUN apk add --no-cache nodejs=~20.15 tini=~0.19
 
 FROM base as builder
 
@@ -13,7 +13,7 @@ COPY package-lock.json /app/
 COPY tsconfig.json /app/
 COPY src/ /app/src/
 
-RUN apk add --no-cache npm=10.2.5-r0 && \
+RUN apk add --no-cache npm=~10.2 && \
     npm ci --no-audit --no-optional --no-update-notifier && \
     npm run build && \
     rm -rf node_modules && \

--- a/tiko/config.json
+++ b/tiko/config.json
@@ -1,6 +1,6 @@
 {
   "name": "tiko / Mon Pilotage Elec",
-  "version": "1.4.7",
+  "version": "2.0.0",
   "slug": "tiko",
   "description": "Control your tiko / Mon Pilotage Elec heaters",
   "image": "ghcr.io/marvinroger/hass-addon-tiko-{arch}",

--- a/tiko/src/hass.ts
+++ b/tiko/src/hass.ts
@@ -22,6 +22,7 @@ export function computeHassMqttConfiguration(
     const climateEntityTopic = `${HASS_MQTT_DISCOVERY_PREFIX}/climate/${fqid}`;
     const climateStateTopic = `${climateEntityTopic}/state`;
     const climateCommandTopic = `${climateEntityTopic}/set`;
+    const climateActionTopic = `${climateEntityTopic}/action`;
 
     const energyEntityTopic = `${HASS_MQTT_DISCOVERY_PREFIX}/sensor/${fqid}`;
     const energyStateTopic = `${energyEntityTopic}/state`;
@@ -89,17 +90,26 @@ export function computeHassMqttConfiguration(
           preset_mode_command_topic: climateCommandTopic,
           preset_mode_command_template:
             '{{ {"type": "presetMode", "presetMode": value} | tojson }}',
+          action_template:"{{ value_json.action }}",
+          action_topic: climateActionTopic,
         }),
       },
       {
         topic: climateStateTopic,
         retain: true,
         message: JSON.stringify({
-          mode: room.heating ? "heat" : "off",
+          mode: room.presetMode != "off" ? "heat" : "off",
           current_humidity: room.currentHumidity,
           current_temperature: room.currentTemperature,
           target_temperature: room.targetTemperature,
           preset_mode: room.presetMode,
+        }),
+      },
+      {
+        topic: climateActionTopic,
+        retain: true,
+        message: JSON.stringify({
+          action: room.heating ? "heating" : "idle"
         }),
       },
       {

--- a/tiko/src/tiko/mappers.ts
+++ b/tiko/src/tiko/mappers.ts
@@ -9,9 +9,7 @@ type TikoPresetMode = {
   frost: boolean;
 };
 
-export function mapPresetMode(
-  mode: TikoPresetMode
-): Result<PresetMode | undefined, Error> {
+export function mapPresetMode(mode: TikoPresetMode): Result<PresetMode, Error> {
   const onModes = Object.entries(mode)
     .filter(([, on]) => on)
     .map(([key]) => key);
@@ -93,7 +91,7 @@ type Room = {
   currentTemperature: number | undefined;
   currentHumidity: number | undefined;
   targetTemperature: number;
-  presetMode: PresetMode | undefined;
+  presetMode: PresetMode;
   heating: boolean;
 };
 


### PR DESCRIPTION
Hi
Regarding https://github.com/marvinroger/hass-addon-tiko/issues/24
I update mode and action based on states in tiko/Mon Pilotage Elec API.

If preset is off (when enabling off switch on MPE), mode is set to off as the climate is disabled. Instead, it's set to heat as the climate will heat depending on the target temperature.

And if it's currently heating, action is set to heating, or idle if not, in an action mqtt topic.
It causes HA UI seeing a red hallow on UI when radiators are really heating.

It also allow other integrations to work with like Versatile Thermostat.

I just builded a custom docker image to run on my own HA installation and it seems to work, but I didnt tested all the cases.

And I also updated node version due to a build error on apk add.
Many thanks